### PR TITLE
remove react and react-dom scripts from index.html

### DIFF
--- a/02-js-tools/src/index.html
+++ b/02-js-tools/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/03-jsx/src/index.html
+++ b/03-jsx/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/04-hooks/src/index.html
+++ b/04-hooks/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/05-useeffect/src/index.html
+++ b/05-useeffect/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/06-custom-hooks/src/index.html
+++ b/06-custom-hooks/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/07-component-composition/src/index.html
+++ b/07-component-composition/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/08-react-router/src/index.html
+++ b/08-react-router/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/09-managing-state-in-class-components/src/index.html
+++ b/09-managing-state-in-class-components/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/10-error-boundaries/src/index.html
+++ b/10-error-boundaries/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/11-context/src/index.html
+++ b/11-context/src/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/12-portals-and-refs/src/index.html
+++ b/12-portals-and-refs/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/code-splitting/src/index.html
+++ b/code-splitting/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/redux/src/index.html
+++ b/redux/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/server-side-rendering-1/src/index.html
+++ b/server-side-rendering-1/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./ClientApp.js"></script>
 </body>
 

--- a/server-side-rendering-2/src/index.html
+++ b/server-side-rendering-2/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./ClientApp.js"></script>
 </body>
 

--- a/tailwindcss/src/index.html
+++ b/tailwindcss/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/testing/src/index.html
+++ b/testing/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/typescript-1/src/index.html
+++ b/typescript-1/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/typescript-2/src/index.html
+++ b/typescript-2/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/typescript-3/src/index.html
+++ b/typescript-3/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/typescript-4/src/index.html
+++ b/typescript-4/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.js"></script>
 </body>
 

--- a/typescript-5/src/index.html
+++ b/typescript-5/src/index.html
@@ -12,8 +12,6 @@
 <body>
   <div id="modal"></div>
   <div id="root">not rendered</div>
-  <script src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
   <script type="module" src="./App.tsx"></script>
 </body>
 


### PR DESCRIPTION
This commit will remove the `react` and `react-dom` script tags from the `index.html` file in all projects excluding `01-no-frills-react`.